### PR TITLE
Stub legal pages

### DIFF
--- a/config/mkdocs.yml
+++ b/config/mkdocs.yml
@@ -5,25 +5,9 @@ docs_dir: ../content
 repo_url: https://github.com/base4nfdi/website-template-mkdocs
 repo_name: "Base4NFDI mkdocs template"
 edit_uri_template: '-/edit/main/{path}'
+
 extra_css:
     - stylesheets/extra.css
-footer:
-    copyright: "&copy 2024 TODO4NFDI, <a href='https://base4nfdi.de/'>Base4NFDI</a>"
-    lines: 
-        - "Partially funded by DFG as part of NFDI."
-        - "Grant Number 521466146"
-    links:
-        - name: Contact
-          link: https://base4nfdi.github.io/website-template-mkdocs/contact/
-        - name: Legal Notice
-          link: https://base4nfdi.github.io/website-template-hugo/imprint/
-        - name: Privacy Policy
-          link: https://base4nfdi.github.io/website-template-hugo/privacy/
-    license:
-        description: This documentation is licensed under CC BY-SA 4.0
-        link: https://creativecommons.org/licenses/by-sa/4.0/legalcode
-        logo: images/cc-by-sa_icon.png
-
 theme:
     name: material
     hightlightjs: true
@@ -54,6 +38,34 @@ theme:
           toggle:
             icon: material/lightbulb-outline
             name: Switch to light mode
+
+extra:
+    generator: false
+    social:
+      - icon: fontawesome/brands/github
+        link: https://github.com/base4nfdi/website-template-mkdocs
+    # social:
+    #   - icon: images/cc-by-sa_icon.png
+    #     link: https://codebase.helmholtz.cloud/m-team/nfdi/nfdi-aai-doc/
+    footer:
+      copyright: "&copy 2024 TODO4NFDI, <a href='https://base4nfdi.de/'>Base4NFDI</a>"
+      lines: 
+          - "Partially funded by DFG as part of NFDI."
+          - "Grant Number 521466146"
+      links: # can be relative or absolute. Relative links will be prepended the site_url value
+          - name: Contact
+            link: /contact/
+          - name: Imprint
+            link: /imprint/
+          - name: Privacy Policy
+            link: /privacy/
+          - name: Accessibility
+            link: /accessibility/
+      license:
+          description: This documentation is licensed under CC BY-SA 4.0
+          link: https://creativecommons.org/licenses/by-sa/4.0/legalcode
+          logo: images/cc-by-sa_icon.png
+
 markdown_extensions:
     - smarty
     - toc:
@@ -72,14 +84,6 @@ markdown_extensions:
     - pymdownx.tabbed:
         alternate_style: true
 
-extra:
-    generator: false
-    social:
-      - icon: fontawesome/brands/github
-        link: https://github.com/base4nfdi/website-template-mkdocs
-    # social:
-    #   - icon: images/cc-by-sa_icon.png
-    #     link: https://codebase.helmholtz.cloud/m-team/nfdi/nfdi-aai-doc/
 plugins:
     - exclude:
           glob:
@@ -99,3 +103,8 @@ nav:
     - Events: events.md
     - People: people.md
     - Contact: contact.md
+
+not_in_nav: |
+  accessibility.md
+  imprint.md
+  privacy.md

--- a/config/mkdocs.yml
+++ b/config/mkdocs.yml
@@ -108,3 +108,9 @@ not_in_nav: |
   accessibility.md
   imprint.md
   privacy.md
+
+validation: #recommended mkdocs validation settings 
+  omitted_files: warn 
+  absolute_links: warn 
+  unrecognized_links: warn 
+  anchors: warn

--- a/content/accessibility.md
+++ b/content/accessibility.md
@@ -1,0 +1,7 @@
+{% include 'logo.md' %}
+
+# Accessibility Information
+
+Please include your accessibility information here. For reference see [https://base4nfdi.github.io/website-template-hugo/accessibility/](https://base4nfdi.github.io/website-template-hugo/accessibility/)
+
+{% include 'gitinfo.md' %}

--- a/content/imprint.md
+++ b/content/imprint.md
@@ -1,0 +1,7 @@
+{% include 'logo.md' %}
+
+# Imprint
+
+Please include your imprint here. For reference see [https://base4nfdi.github.io/website-template-hugo/imprint/](https://base4nfdi.github.io/website-template-hugo/imprint/)
+
+{% include 'gitinfo.md' %}

--- a/content/privacy.md
+++ b/content/privacy.md
@@ -1,0 +1,7 @@
+{% include 'logo.md' %}
+
+# Privacy Policy
+
+Please include your privacy policy here. For reference see [https://base4nfdi.github.io/website-template-hugo/privacy/](https://base4nfdi.github.io/website-template-hugo/privacy/)
+
+{% include 'gitinfo.md' %}

--- a/overrides/partials/footer.html
+++ b/overrides/partials/footer.html
@@ -44,26 +44,30 @@
     {% endif %}
     <div class="md-footer-meta md-typeset">
         <div class="footer-copyright">
-            {% if config.footer.copyright %}
+            {% if config.extra.footer.copyright %}
               <div class="md-copyright__highlight">
-                {{ config.footer.copyright }}
+                {{ config.extra.footer.copyright }}
               </div>
             {% endif %}
         </div>
         <div class="footer-lines footer-textstyle">
-            {% for line in config.footer.lines %}
+            {% for line in config.extra.footer.lines %}
             {{ line }}<br>
             {% endfor %}
         </div>
         <nav class="footer-nav footer-textstyle">
-            {% for item in config.footer.links %}
+            {% for item in config.extra.footer.links %}
             {% set title = item.name %}
             {% if not title and "//" in item.link %}
                 {% set _, url = item.link.split("//") %}
             {% endif %}
+            {% if not "//" in item.link %}
+                {% set link = config.site_url + item.link %}
+            {% else %}
+                {% set link = item.link %}
+            {% endif %}
             <a
-                href="{{ item.link }}"
-                target="_blank" rel="noopener"
+                href="{{ link }}"
                 title="{{ title | e }}"
                 class="md-footer-link"
             >
@@ -72,9 +76,8 @@
             {% endfor %}
         </nav>
         <div class="footer-license footer-textstyle">
-            {% set link = config.footer.license.link %}
-            {% set logo = config.site_url + '/' + config.footer.license.logo %}
-            {% set description = config.footer.license.description %}
+            {% set link = config.extra.footer.license.link %}
+            {% set logo = config.site_url + '/' + config.extra.footer.license.logo %}
             <p style="font-size: .8rem; margin-right: 20px;">{{ description }}</p>
             <a href="{{ link }}" target="_blank" rel="noopener">
                 <img src="{{ logo }}">


### PR DESCRIPTION
Add stub pages for imprint, privacy and accessibility. Also make relative links in the footer possible and move the config to the right place.